### PR TITLE
Add ring descriptor utilities

### DIFF
--- a/QRCI/QRCI.py
+++ b/QRCI/QRCI.py
@@ -1,0 +1,146 @@
+from collections import namedtuple
+import math
+from typing import Iterable, Union
+
+from rdkit import Chem
+from rdkit.Chem import Descriptors
+
+from .utils import calculate_strain_factor, count_macrocycles
+
+
+def calculate_QRCI(
+    smiles_or_mol: Union[str, Chem.Mol],
+    weights: Iterable[float] | None = None,
+    normalize: bool = True,
+    W_macro: float = 2.0,
+) -> float | None:
+    """Compute the Quantitative Ring Complexity Index."""
+    if weights is None:
+        weights = (1.3, 0.9, 1.2, 0.9, 0.9, 1.1)
+
+    if isinstance(smiles_or_mol, str):
+        mol = Chem.MolFromSmiles(smiles_or_mol)
+        if mol is None:
+            return None
+    else:
+        mol = smiles_or_mol
+
+    ri = mol.GetRingInfo()
+    rings = ri.AtomRings()
+    n_ring = len(rings)
+    if n_ring == 0:
+        return 0.0
+
+    TRS = sum(len(ring) for ring in rings)
+    n_ring_atom = len({atom for ring in rings for atom in ring})
+    n_fused_ring = sum(
+        1 for ring in rings if any(set(ring) & set(other) for other in rings if ring != other)
+    )
+    SF = calculate_strain_factor(mol, rings)
+    n_total_atom = mol.GetNumAtoms()
+
+    n_arom_hetero = Descriptors.NumAromaticHeterocycles(mol)
+    n_arom_carbo = Descriptors.NumAromaticCarbocycles(mol)
+    n_ali_hetero = Descriptors.NumAliphaticHeterocycles(mol)
+    n_ali_carbo = Descriptors.NumAliphaticCarbocycles(mol)
+    n_sat_carbo = Descriptors.NumSaturatedCarbocycles(mol)
+    n_sat_hetero = Descriptors.NumSaturatedHeterocycles(mol)
+    n_macro = count_macrocycles(mol)
+
+    normalization_factor = (
+        math.sqrt(n_ring_atom * TRS) if normalize and n_ring_atom * TRS > 0 else 1
+    )
+
+    chemical_diversity = (
+        weights[0] * n_arom_hetero
+        + weights[1] * n_arom_carbo
+        + weights[2] * n_ali_hetero
+        + weights[3] * n_ali_carbo
+        + weights[4] * n_sat_carbo
+        + weights[5] * n_sat_hetero
+    ) / normalization_factor
+
+    structural_contribution = (
+        TRS / n_ring_atom if n_ring_atom > 0 else 0
+    ) * (1 + n_fused_ring / (n_ring + 1))
+    molecular_context = (
+        math.log(n_total_atom ** 0.5) / (n_ring + 1) if n_total_atom > 1 else 0
+    )
+    macrocycle_contribution = W_macro * (n_macro / (n_ring + 1)) if n_ring > 0 else 0
+
+    return (
+        structural_contribution
+        + SF
+        + chemical_diversity
+        + molecular_context
+        + macrocycle_contribution
+    )
+
+
+QRCIproperties = namedtuple(
+    "QRCIproperties",
+    [
+        "nAromHetero",
+        "nAromCarbo",
+        "nAliHetero",
+        "nAliCarbo",
+        "nSatHetero",
+        "nSatCarbo",
+        "nMacrocycles",
+        "TRS",
+        "nRingAtom",
+        "nFusedRing",
+        "SF",
+    ],
+)
+
+
+def get_QRCIproperties(mol: Chem.Mol) -> QRCIproperties:
+    ri = mol.GetRingInfo()
+    rings = ri.AtomRings()
+    TRS = sum(len(ring) for ring in rings)
+    n_ring_atom = len({atom for ring in rings for atom in ring})
+    n_fused_ring = sum(
+        1 for ring in rings if any(set(ring) & set(other) for other in rings if ring != other)
+    )
+    SF = calculate_strain_factor(mol, rings)
+
+    return QRCIproperties(
+        nAromHetero=Descriptors.NumAromaticHeterocycles(mol),
+        nAromCarbo=Descriptors.NumAromaticCarbocycles(mol),
+        nAliHetero=Descriptors.NumAliphaticHeterocycles(mol),
+        nAliCarbo=Descriptors.NumAliphaticCarbocycles(mol),
+        nSatHetero=Descriptors.NumSaturatedHeterocycles(mol),
+        nSatCarbo=Descriptors.NumSaturatedCarbocycles(mol),
+        nMacrocycles=count_macrocycles(mol),
+        TRS=TRS,
+        nRingAtom=n_ring_atom,
+        nFusedRing=n_fused_ring,
+        SF=SF,
+    )
+
+
+class QRCICalculator:
+    def __init__(self, weights: Union[str, Iterable[float]] = "mean", normalize: bool = True, w_macro: float = 2.0):
+        self.normalize = normalize
+        self.w_macro = w_macro
+        self.weights = self._get_weights(weights)
+
+    def _get_weights(self, mode: Union[str, Iterable[float]]):
+        if mode == "mean":
+            return [1.3, 0.9, 1.2, 0.9, 0.9, 1.1]
+        elif mode == "max":
+            return [1.5, 1.2, 1.3, 1.1, 1.0, 1.0]
+        elif mode == "unit":
+            return [1.0] * 6
+        elif isinstance(mode, (list, tuple)) and len(mode) == 6:
+            return list(mode)
+        else:
+            raise ValueError(
+                "Invalid weight mode or custom weights must be a list/tuple of length 6."
+            )
+
+    def __call__(self, mol: Chem.Mol) -> float:
+        return calculate_QRCI(
+            mol, weights=self.weights, normalize=self.normalize, W_macro=self.w_macro
+        )

--- a/QRCI/RCI.py
+++ b/QRCI/RCI.py
@@ -1,0 +1,43 @@
+from typing import Union
+from rdkit import Chem
+
+
+def calculate_RCI(smiles_or_mol: Union[str, Chem.Mol]) -> float | None:
+    """Calculate the Ring Complexity Index (RCI).
+
+    Parameters
+    ----------
+    smiles_or_mol : str | Chem.Mol
+        Molecule given as a SMILES string or RDKit Mol object.
+
+    Returns
+    -------
+    float | None
+        The RCI value or ``None`` if the molecule could not be parsed.
+    """
+    if isinstance(smiles_or_mol, str):
+        mol = Chem.MolFromSmiles(smiles_or_mol)
+        if mol is None:
+            return None
+    else:
+        mol = smiles_or_mol
+
+    ring_info = mol.GetRingInfo()
+    rings = ring_info.AtomRings()
+    if not rings:
+        return 0.0
+
+    TRS = sum(len(ring) for ring in rings)
+    n_ring_atoms = len({atom for ring in rings for atom in ring})
+    if n_ring_atoms == 0:
+        return 0.0
+
+    return TRS / n_ring_atoms
+
+
+class RCICalculator:
+    """Callable class returning the Ring Complexity Index."""
+
+    def __call__(self, smiles_or_mol: Union[str, Chem.Mol]) -> float | None:
+        return calculate_RCI(smiles_or_mol)
+

--- a/QRCI/__init__.py
+++ b/QRCI/__init__.py
@@ -1,0 +1,16 @@
+from .QRCI import (
+    calculate_QRCI,
+    get_QRCIproperties,
+    QRCIproperties,
+    QRCICalculator,
+)
+from .RCI import calculate_RCI, RCICalculator
+
+__all__ = [
+    "calculate_QRCI",
+    "calculate_RCI",
+    "get_QRCIproperties",
+    "QRCIproperties",
+    "QRCICalculator",
+    "RCICalculator",
+]

--- a/QRCI/ring_descriptors.py
+++ b/QRCI/ring_descriptors.py
@@ -1,0 +1,214 @@
+"""Ring descriptor helper functions for QRCI package."""
+
+from rdkit import Chem
+from rdkit.Chem import AllChem, rdmolops, rdMolDescriptors
+
+
+# Calculates the total number of stereocenters
+def get_num_stereocenters(mol: Chem.Mol) -> int:
+    """Return the total number of specified and unspecified stereocenters."""
+    return AllChem.CalcNumAtomStereoCenters(mol) + AllChem.CalcNumUnspecifiedAtomStereoCenters(mol)
+
+
+# calculate the number of macrocycle
+def get_num_macrocycles(mol: Chem.Mol, min_ring_size: int = 12) -> int:
+    """Return the number of rings with size >= ``min_ring_size``."""
+    if mol is None:
+        return 0
+    sssr = Chem.GetSymmSSSR(mol)
+    count = 0
+    for ring in sssr:
+        if len(ring) >= min_ring_size:
+            count += 1
+    return count
+
+
+# Calculate the number of heteroatoms
+def calculate_number_of_heteroatoms(mol: Chem.Mol) -> int | None:
+    """Return the number of heteroatoms (non H or C) in the molecule."""
+    if mol is None or not hasattr(mol, "GetAtoms"):
+        return None
+    heteroatoms = [atom for atom in mol.GetAtoms() if atom.GetAtomicNum() not in (1, 6)]
+    return len(heteroatoms)
+
+
+# calculate the number of ring atoms
+def count_ring_atoms(mol: Chem.Mol) -> int | None:
+    """Return the number of atoms that are part of any ring."""
+    if mol is None:
+        return None
+    return sum(1 for atom in mol.GetAtoms() if atom.IsInRing())
+
+
+# Calculates the ratio of heteroatoms to heavy atoms
+def calculate_heteroatom_ratio(mol: Chem.Mol) -> float | None:
+    """Return the ratio of heteroatoms to heavy atoms."""
+    if mol is None:
+        return None
+    num_heavy_atoms = mol.GetNumHeavyAtoms()
+    if num_heavy_atoms == 0:
+        return 0.0
+    num_heteroatoms = sum(1 for atom in mol.GetAtoms() if atom.GetAtomicNum() not in (1, 6))
+    heteroatom_ratio = num_heteroatoms / num_heavy_atoms
+    return heteroatom_ratio
+
+
+# calculate the number of isolated rings
+def calculate_nIR(mol: Chem.Mol) -> int | None:
+    """Return the number of isolated rings (nIR)."""
+    if mol is None:
+        return None
+    sssr = rdmolops.GetSymmSSSR(mol)
+    ring_list = [set(ring) for ring in sssr]
+    isolated_rings = 0
+    for i, ring_i in enumerate(ring_list):
+        is_isolated = all(ring_i.isdisjoint(ring_j) for j, ring_j in enumerate(ring_list) if i != j)
+        if is_isolated:
+            isolated_rings += 1
+    return isolated_rings
+
+
+# calculate the number of fused rings
+def calculate_nFR(mol: Chem.Mol) -> int | None:
+    """Return the number of fused rings (nFR)."""
+    if mol is None:
+        return None
+    sssr = rdmolops.GetSymmSSSR(mol)
+    total_rings = len(sssr)
+    nIR = calculate_nIR(mol)
+    nFR = total_rings - nIR
+    return nFR
+
+
+# calculate the total ring size (TRS)
+def calculate_TRS(mol: Chem.Mol) -> int | None:
+    """Return the total ring size (sum of all ring sizes)."""
+    if mol is None:
+        return None
+    sssr = rdmolops.GetSymmSSSR(mol)
+    total_ring_size = sum(len(ring) for ring in sssr)
+    return total_ring_size
+
+
+# calculate sum of all bonds forming the rings
+def calculate_Rperim(mol: Chem.Mol) -> int | None:
+    """Return the total ring perimeter (equivalent to ``calculate_TRS``)."""
+    if mol is None:
+        return None
+    return calculate_TRS(mol)
+
+
+# Calculate the Number of Ring Systems (NRS)
+def calculate_nrs(mol: Chem.Mol) -> int | None:
+    """Return the number of ring systems (NRS)."""
+    if mol is None:
+        return None
+    nBO = mol.GetNumBonds()
+    nSK = mol.GetNumHeavyAtoms()
+    B_R = sum(bond.IsInRing() for bond in mol.GetBonds())
+    A_R = sum(atom.IsInRing() for atom in mol.GetAtoms())
+    nStructures = len(rdmolops.GetMolFrags(mol, asMols=True))
+    NRS = (nBO - B_R) - (nSK - A_R) + nStructures
+    return NRS
+
+
+# calculate Normalized Number of Ring Systems (NNRS)
+def calculate_cyclomatic_number(mol: Chem.Mol) -> int | None:
+    """Return the cyclomatic number (nCIC)."""
+    if mol is None:
+        return None
+    nBO = mol.GetNumBonds()
+    nSK = mol.GetNumHeavyAtoms()
+    nStructures = len(rdmolops.GetMolFrags(mol, asMols=True))
+    nCIC = nBO - nSK + nStructures
+    return nCIC
+
+
+def calculate_nnrs(mol: Chem.Mol) -> float | None:
+    """Return the Normalized Number of Ring Systems (NNRS)."""
+    if mol is None:
+        return None
+    nrs = calculate_nrs(mol)
+    nCIC = calculate_cyclomatic_number(mol)
+    if nCIC is None or nCIC == 0:
+        return None
+    nnrs = nrs / nCIC
+    return nnrs
+
+
+# Molecular Cyclized Degree (MCD)
+def calculate_mcd(mol: Chem.Mol) -> float | None:
+    """Return the Molecular Cyclized Degree (MCD)."""
+    if mol is None:
+        return None
+    nSK = mol.GetNumHeavyAtoms()
+    nRingAtoms = sum(atom.IsInRing() for atom in mol.GetAtoms())
+    if nSK == 0:
+        return None
+    MCD = nRingAtoms / nSK
+    return MCD
+
+
+# calculate Ring Fusion Density (RFD)
+def calculate_ring_fusion_density(mol: Chem.Mol) -> float | None:
+    """Return the Ring Fusion Density (RFD)."""
+    if mol is None:
+        return None
+    ring_info = mol.GetRingInfo()
+    atom_rings = ring_info.AtomRings()
+    total_rings = len(atom_rings)
+    if total_rings == 0:
+        return None
+    fused_rings = 0
+    for i, ring1 in enumerate(atom_rings):
+        for j, ring2 in enumerate(atom_rings):
+            if i < j and set(ring1).intersection(set(ring2)):
+                fused_rings += 1
+                break
+    rfd = fused_rings / total_rings
+    return rfd
+
+
+# calculate Aromatic Ratio (ARR)
+def Calc_ARR(mol: Chem.Mol) -> float:
+    """Return the Aromatic Ratio (ARR)."""
+    m = Chem.RemoveHs(mol)
+    num_bonds = m.GetNumBonds()
+    if num_bonds == 0:
+        return 0.0
+    num_aromatic_bonds = sum(1 for bond in m.GetBonds() if bond.GetIsAromatic())
+    ARR = num_aromatic_bonds / num_bonds
+    return round(ARR, 4)
+
+
+# Calculate the aromatic-sp3 carbon balance for a molecule.
+def Calc_Ar_Alk_balance(mol: Chem.Mol) -> int:
+    """Return difference between aromatic and sp3 carbons."""
+    m = Chem.RemoveHs(mol)
+    num_aromatic_carbon = sum(
+        1 for atom in m.GetAromaticAtoms() if atom.GetSymbol() == "C"
+    )
+    num_sp3_carbon = sum(
+        1
+        for atom in m.GetAtoms()
+        if atom.GetHybridization() == Chem.rdchem.HybridizationType.SP3 and atom.GetSymbol() == "C"
+    )
+    return num_aromatic_carbon - num_sp3_carbon
+
+
+# Calculates the ratio of HeteroRings to all rings
+def calculate_heterorings_ratio(mol: Chem.Mol) -> float | None:
+    """Return the ratio of heteroatom-containing rings to total rings."""
+    if mol is None:
+        return None
+    total_rings = rdMolDescriptors.CalcNumRings(mol)
+    if total_rings == 0:
+        return 0.0
+    ring_info = mol.GetRingInfo()
+    atom_rings = ring_info.AtomRings()
+    hetero_rings = sum(
+        any(mol.GetAtomWithIdx(idx).GetAtomicNum() not in (6, 1) for idx in ring)
+        for ring in atom_rings
+    )
+    heterorings_ratio = hetero_rings / total_rings
+    return round(heterorings_ratio, 4)

--- a/QRCI/utils.py
+++ b/QRCI/utils.py
@@ -1,0 +1,36 @@
+from typing import Iterable
+
+from rdkit import Chem
+
+
+def calculate_ideal_internal_angle_sum(ring_size: int) -> float:
+    """Return the ideal internal angle sum for a ring of given size."""
+    return (ring_size - 2) * 180 / ring_size
+
+
+def calculate_strain_factor(
+    mol: Chem.Mol,
+    rings: Iterable[Iterable[int]],
+    lambda_macrocycle: float = 0.5,
+    macrocycle_threshold: int = 12,
+) -> float:
+    """Calculate strain factor with reduced contribution for macrocycles."""
+    strain_factor = 0.0
+    for ring in rings:
+        ring_size = len(ring)
+        ideal_angle_sum = calculate_ideal_internal_angle_sum(ring_size)
+        lambda_M = lambda_macrocycle if ring_size >= macrocycle_threshold else 1.0
+        strain_factor += (360 / (360 - ideal_angle_sum)) / ring_size * lambda_M
+    return strain_factor
+
+
+def count_macrocycles(mol: Chem.Mol, min_ring_size: int = 12) -> int:
+    """Return number of rings with size >= ``min_ring_size``."""
+    if mol is None:
+        return 0
+    sssr = Chem.GetSymmSSSR(mol)
+    count = 0
+    for ring in sssr:
+        if len(ring) >= min_ring_size:
+            count += 1
+    return count

--- a/README.md
+++ b/README.md
@@ -31,11 +31,24 @@ Ref: Gasteiger, J., & Jochum, C. (1979). An Algorithm for the Perception of Synt
 ![RCI of Drug](https://github.com/AspirinCode/QRCI/blob/main/figures/drugbank5.1.13_apvd_r1r10w900_rci_histdist.png)
 **Distribution of RCI for approved drugs of DrugBank**
 
+```python
+from qrci import calculate_RCI
+
+rci_value = calculate_RCI("C1CCCCC1")
+print(f"RCI: {rci_value:.2f}")
+```
+
 ## Requirements
 ```python
 Python==3.13.2
 rdkit==2025.03.2
 scipy==1.15.1
+```
+
+## Installation
+
+```bash
+pip install qrci
 ```
 
 ## Data
@@ -69,10 +82,24 @@ print(f"QRCI(default/mean weights): {score_mean:.4f}")
 
 ***************************************************************************************
 mol = Chem.MolFromSmiles('C1=CCOCc2cc(ccc2OCCN2CCCC2)Nc2nccc(n2)-c2cccc(c2)COC1')
-props = get_qrci_properties(mol)
+props = get_QRCIproperties(mol)
 print(props)
 #QRCIproperties(nAromHetero=1, nAromCarbo=2, nAliHetero=2, nAliCarbo=0, nSatHetero=1, nSatCarbo=0, nMacrocycles=1)
 
+```
+
+```python
+from QRCI.utils import calculate_strain_factor
+from QRCI.QRCI import QRCICalculator
+from QRCI.RCI import RCICalculator
+
+smiles = 'C1=CCOCc2cc(ccc2OCCN2CCCC2)Nc2nccc(n2)-c2cccc(c2)COC1'
+qrci_calc = QRCICalculator(weights='max')
+rci_calc = RCICalculator()
+qrci_max = qrci_calc(smiles)
+rci_value = rci_calc(smiles)
+print(f"QRCI(max weights): {qrci_max:.3f}")
+print(f"RCI: {rci_value:.2f}")
 ```
 
 ![RCI of Drug](https://github.com/AspirinCode/QRCI/blob/main/figures/drugbank5.1.13_apvd_r1r10w900_qrci_histdist.png)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qrci"
+version = "0.1.0"
+description = "Quantitative Ring Complexity Index"
+readme = "README.md"
+authors = [{name="Jianmin Wang"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+
+dependencies = [
+    "rdkit",
+    "numpy"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["QRCI*"]


### PR DESCRIPTION
## Summary
- implement `ring_descriptors.py` with helper functions like `get_num_macrocycles`, `calculate_nrs`, `calculate_ring_fusion_density` and more

## Testing
- `python -m py_compile QRCI/QRCI.py QRCI/RCI.py QRCI/utils.py QRCI/ring_descriptors.py QRCI/__init__.py QRCI/npscorer.py QRCI/sascorer.py`
- `python -m build` *(fails: No module named build)*
- `pip install -e . --no-deps` *(fails: installing build dependencies error)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd0fc2e0832e9ef7c981cbe24a16